### PR TITLE
Fix client designs path helpers

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2488,3 +2488,528 @@ nav {
   display: flex;
   justify-content: flex-start;
 }
+
+.documents-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.documents-nav__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.95rem;
+  border: 1px solid #eadcc7;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #3c2e25;
+  font-weight: 600;
+  background: #fffaf1;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.documents-nav__link:hover,
+.documents-nav__link:focus {
+  background: #f8f1e5;
+  border-color: #d9c4aa;
+}
+
+.documents-nav__link--active {
+  background: #3c2e25;
+  color: #fffaf1;
+  border-color: #3c2e25;
+}
+
+.documents-nav__link--active .documents-nav__count {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fffaf1;
+}
+
+.documents-nav__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0 0.45rem;
+  border-radius: 999px;
+  background: #f0dfc8;
+  color: #3c2e25;
+  font-size: 0.8rem;
+}
+
+.documents-table {
+  border: 1px solid #eadcc7;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fffaf1;
+}
+
+.documents-table__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.documents-table__header {
+  background: #f8f1e5;
+  text-align: left;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.75rem 1rem;
+  color: #8a6d58;
+}
+
+.documents-table__row:nth-child(even) {
+  background: #fffbf4;
+}
+
+.documents-table__row--outdated {
+  opacity: 0.85;
+}
+
+.documents-table__row--active {
+  border-left: 4px solid #3c2e25;
+}
+
+.documents-table__cell {
+  padding: 1rem;
+  vertical-align: top;
+  color: #3c2e25;
+  border-bottom: 1px solid #eadcc7;
+}
+
+.documents-table__cell:last-child {
+  white-space: nowrap;
+}
+
+.documents-table__cell--actions {
+  min-width: 220px;
+}
+
+.documents-table__title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.documents-table__title-link {
+  color: #3c2e25;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.documents-table__title-link:hover,
+.documents-table__title-link:focus {
+  text-decoration: underline;
+}
+
+.documents-table__title-label {
+  font-weight: 600;
+}
+
+.documents-table__title-badge {
+  font-size: 0.85rem;
+}
+
+.documents-table__meta {
+  display: flex;
+  gap: 0.3rem;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: #8a6d58;
+}
+
+.documents-table__meta-label {
+  font-weight: 600;
+}
+
+.documents-table__meta-value {
+  color: #3c2e25;
+}
+
+.documents-table__hint {
+  margin-top: 0.3rem;
+  font-size: 0.8rem;
+  color: #8a6d58;
+}
+
+.documents-table__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.documents-table__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.documents-table__action {
+  color: #3c2e25;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.documents-table__action:hover,
+.documents-table__action:focus {
+  text-decoration: underline;
+}
+
+.documents-table__action--current {
+  font-style: italic;
+  color: #8a6d58;
+}
+
+.documents-table__badge {
+  display: inline-block;
+  border: 1px solid #3c2e25;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.documents-table__status {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.documents-table__status--latest {
+  background: #2f6b3a;
+  color: #fffaf1;
+}
+
+.documents-table__status--archived {
+  background: #f0dfc8;
+  color: #3c2e25;
+}
+
+.documents-table__empty {
+  padding: 2.5rem;
+  text-align: center;
+  color: #8a6d58;
+}
+
+.documents-show__body {
+  display: grid;
+  gap: 2rem;
+}
+
+.documents-show__summary {
+  border: 1px solid #eadcc7;
+  border-radius: 12px;
+  padding: 1.75rem;
+  background: #fffaf1;
+}
+
+.documents-show__heading {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  color: #3c2e25;
+}
+
+.documents-show__subheading {
+  margin: 1.25rem 0 0.5rem;
+  font-size: 1rem;
+  color: #3c2e25;
+}
+
+.documents-show__meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.documents-show__meta-grid dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #8a6d58;
+  margin-bottom: 0.25rem;
+}
+
+.documents-show__meta-grid dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.documents-show__primary-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.documents-show__action {
+  color: #3c2e25;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.documents-show__action:hover,
+.documents-show__action:focus {
+  text-decoration: underline;
+}
+
+.documents-show__danger {
+  background: none;
+  border: none;
+  color: #a13d34;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.documents-show__attachments {
+  border: 1px solid #eadcc7;
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #fff;
+}
+
+.documents-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.documents-form__errors {
+  border: 1px solid #a13d34;
+  background: #f8e2df;
+  padding: 1rem 1.25rem;
+  border-radius: 10px;
+  color: #3c2e25;
+}
+
+.documents-form__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+}
+
+@media (max-width: 900px) {
+  .documents-form__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.documents-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.documents-form__input,
+.documents-form__select,
+.documents-form__file-field {
+  padding: 0.65rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d9c4aa;
+  font-size: 1rem;
+  color: #3c2e25;
+  background: #fff;
+}
+
+.documents-form__file-field {
+  padding: 0.45rem;
+}
+
+.documents-form__upload-status,
+.documents-form__hint {
+  font-size: 0.85rem;
+  color: #8a6d58;
+}
+
+.documents-form__checkbox {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-weight: 600;
+}
+
+.documents-form__actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.documents-form__submit {
+  background: #3c2e25;
+  color: #fffaf1;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.documents-form__submit:hover,
+.documents-form__submit:focus {
+  background: #2f231b;
+}
+
+.documents-form__cancel {
+  color: #3c2e25;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.documents-form__cancel:hover,
+.documents-form__cancel:focus {
+  text-decoration: underline;
+}
+
+.documents-form__context {
+  border: 1px solid #eadcc7;
+  border-radius: 12px;
+  padding: 1.25rem;
+  background: #fffaf1;
+}
+
+.documents-form__context h2 {
+  margin-top: 0;
+  font-size: 1.05rem;
+  color: #3c2e25;
+}
+
+.documents-form__context h3 {
+  font-size: 0.95rem;
+  margin-top: 1rem;
+  color: #3c2e25;
+}
+
+.documents-form__context-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.documents-form__version-indicator {
+  font-size: 0.85rem;
+}
+
+.documents-form__version-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.documents-form__version-updated {
+  display: block;
+  font-size: 0.8rem;
+  color: #8a6d58;
+}
+
+.documents-form__version-more {
+  font-size: 0.85rem;
+  color: #8a6d58;
+}
+
+.event-section__cta--secondary {
+  background: #fff;
+  color: #3c2e25;
+  border: 1px solid #eadcc7;
+}
+
+.event-section__cta--secondary:hover,
+.event-section__cta--secondary:focus {
+  background: #f8f1e5;
+}
+
+.client-section {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.client-section__title {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #3c2e25;
+}
+
+.client-upload {
+  border: 1px solid #eadcc7;
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #fffaf1;
+  display: grid;
+  gap: 1rem;
+}
+
+.client-upload__title {
+  margin: 0;
+  font-size: 1rem;
+  color: #3c2e25;
+}
+
+.client-upload__errors {
+  border: 1px solid #a13d34;
+  background: #f8e2df;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+}
+
+.client-upload__errors ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.client-upload__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.client-upload__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.client-upload__input,
+.client-upload__file {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d9c4aa;
+  font-size: 1rem;
+  color: #3c2e25;
+  background: #fff;
+}
+
+.client-upload__status {
+  font-size: 0.85rem;
+  color: #8a6d58;
+}
+
+.client-upload__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.client-upload__submit {
+  background: #3c2e25;
+  color: #fffaf1;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.client-upload__submit:hover,
+.client-upload__submit:focus {
+  background: #2f231b;
+}

--- a/app/controllers/client/designs_controller.rb
+++ b/app/controllers/client/designs_controller.rb
@@ -1,7 +1,36 @@
 module Client
   class DesignsController < EventScopedController
+    before_action :load_documents, only: %i[index create]
+
     def index
-      @documents = @event.documents.latest.client_visible.order(:title)
+      @new_document = build_new_document
+    end
+
+    def create
+      @new_document = build_new_document
+      @new_document.assign_attributes(document_params)
+
+      if @new_document.save
+        redirect_to client_event_designs_path(@event), notice: "Upload received."
+      else
+        flash.now[:alert] = "Unable to save your upload. Please review the errors below."
+        render :index, status: :unprocessable_content
+      end
+    end
+
+    private
+
+    def load_documents
+      @planner_documents = @event.documents.latest.client_visible.where.not(source: :client_upload).order(:title)
+      @client_documents = @event.documents.latest.where(source: :client_upload).order(updated_at: :desc)
+    end
+
+    def build_new_document
+      @event.documents.new(source: :client_upload, client_visible: true)
+    end
+
+    def document_params
+      params.require(:document).permit(:title, :storage_uri, :checksum, :size_bytes, :content_type, :logical_id)
     end
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,9 +1,10 @@
 class DocumentsController < ApplicationController
   before_action :set_event
   before_action :set_document, only: %i[show edit update destroy download]
+  before_action :load_document_groups, only: %i[index packets staff_uploads client_uploads]
 
   def index
-    @document_groups = build_document_groups
+    @documents = @event.documents.latest.order(updated_at: :desc, title: :asc)
   end
 
   def packets
@@ -21,12 +22,18 @@ class DocumentsController < ApplicationController
   def show
     @attachments = @document.attachments.includes(:entity).order(:context, :position)
     @available_entities = available_entities_for(@event)
-    @versions = Document.where(logical_id: @document.logical_id).order(version: :desc)
+    @versions = versions_for(@document.logical_id)
   end
 
   def new
     @document = @event.documents.new
-    @document.logical_id = params[:logical_id] if params[:logical_id].present?
+    @reference_document = reference_document_for(params[:logical_id])
+    if @reference_document
+      @document.logical_id = @reference_document.logical_id
+    elsif params[:logical_id].present?
+      @document.logical_id = params[:logical_id]
+    end
+    @existing_versions = versions_for(@document.logical_id)
   end
 
   def create
@@ -35,17 +42,21 @@ class DocumentsController < ApplicationController
     if @document.save
       redirect_to event_document_path(@event, @document), notice: "Document saved."
     else
+      @reference_document = reference_document_for(@document.logical_id)
+      @existing_versions = versions_for(@document.logical_id)
       render :new, status: :unprocessable_content
     end
   end
 
   def edit
+    @existing_versions = versions_for(@document.logical_id)
   end
 
   def update
     if @document.update(edit_document_params)
       redirect_to event_document_path(@event, @document), notice: "Document updated."
     else
+      @existing_versions = versions_for(@document.logical_id)
       render :edit, status: :unprocessable_content
     end
   end
@@ -87,9 +98,13 @@ class DocumentsController < ApplicationController
   def render_grouped_documents(source_key)
     @source_key = source_key.to_s
     @label = document_source_label(@source_key)
-    @documents = @event.documents.where(source: @source_key).order(:title)
-    @document_groups = build_document_groups
+    @documents = @event.documents.where(source: @source_key).order(title: :asc, version: :desc)
+    load_document_groups
     render :group
+  end
+
+  def load_document_groups
+    @document_groups = build_document_groups
   end
 
   def build_document_groups
@@ -99,16 +114,22 @@ class DocumentsController < ApplicationController
         key: key,
         label: document_source_label(key),
         documents_count: scope.count,
-        images_count: scope.where("content_type LIKE ?", "image/%").count
+        latest_count: scope.where(is_latest: true).count
       }
     end
   end
 
   def document_source_label(key)
-    {
-      "packet" => "Packets",
-      "staff_upload" => "Uploads",
-      "client_upload" => "Client Uploads"
-    }[key] || key.humanize
+    DocumentsHelper::SOURCE_LABELS[key.to_s] || key.to_s.humanize
+  end
+
+  def versions_for(logical_id)
+    return Document.none if logical_id.blank?
+
+    @event.documents.where(logical_id: logical_id).order(version: :desc)
+  end
+
+  def reference_document_for(logical_id)
+    versions_for(logical_id).first
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,4 +1,10 @@
 module DocumentsHelper
+  SOURCE_LABELS = {
+    "packet" => "Packets",
+    "staff_upload" => "Planner Uploads",
+    "client_upload" => "Client Uploads"
+  }.freeze
+
   def entity_label(entity)
     case entity
     when Event
@@ -21,6 +27,66 @@ module DocumentsHelper
     else
       Document.none
     end
+  end
+
+  def document_source_label_text(key)
+    SOURCE_LABELS[key.to_s] || key.to_s.humanize
+  end
+
+  def document_source_label_for(document)
+    document_source_label_text(document.source)
+  end
+
+  def document_visibility_label(document)
+    document.client_visible? ? "Client visible" : "Planner only"
+  end
+
+  def document_visibility_hint(document)
+    document.client_visible? ? "Shared in client portal" : "Hidden from client portal"
+  end
+
+  def document_uploader_label(document)
+    case document.source
+    when "client_upload"
+      "Client"
+    else
+      "Planning team"
+    end
+  end
+
+  def document_version_badge(document)
+    badge = tag.span("v#{document.version}", class: "documents-table__badge")
+    status = if document.is_latest?
+               tag.span("Latest", class: "documents-table__status documents-table__status--latest")
+             else
+               tag.span("Replaced", class: "documents-table__status documents-table__status--archived")
+             end
+    safe_join([badge, status], " ")
+  end
+
+  def document_latest_explanation(document)
+    document.is_latest? ? "Current version" : "Superseded by a newer upload"
+  end
+
+  def document_updated_timestamp(document)
+    l(document.updated_at, format: :long)
+  end
+
+  def document_size_label(document)
+    number_to_human_size(document.size_bytes)
+  end
+
+  def document_table_header(column)
+    {
+      title: "Title",
+      version: "Version",
+      updated_at: "Updated",
+      visibility: "Visibility",
+      source: "Source",
+      uploader: "Uploader",
+      size: "File size",
+      actions: "Actions"
+    }[column] || column.to_s.humanize
   end
 
   def document_group_path(event, key)

--- a/app/views/client/designs/index.html.erb
+++ b/app/views/client/designs/index.html.erb
@@ -4,18 +4,64 @@
     <p>Preview boards, files, and inspiration shared by your planning team.</p>
   </header>
 
-  <% if @documents.any? %>
-    <ul class="client-list">
-      <% @documents.each do |document| %>
-        <li>
-          <strong><%= document.title %></strong>
-          <span>Version <%= document.version %></span>
-        </li>
+  <div class="client-section">
+    <h2 class="client-section__title">Planner uploads</h2>
+    <%= render "documents/table", event: @event, documents: @planner_documents,
+              columns: %i[title version updated_at size actions],
+              context: :client,
+              paths: { view: nil, replace: nil, edit: nil, download: ->(doc) { download_event_document_path(@event, doc) } },
+              empty_message: "No inspiration files yet. Your planner will add items once they’re ready." %>
+  </div>
+
+  <div class="client-section">
+    <h2 class="client-section__title">Your uploads</h2>
+    <%= render "documents/table", event: @event, documents: @client_documents,
+              columns: %i[title version updated_at size actions],
+              context: :client,
+              paths: { view: nil, replace: nil, edit: nil, download: ->(doc) { download_event_document_path(@event, doc) } },
+              empty_message: "You haven’t shared any inspiration yet." %>
+
+    <div class="client-upload">
+      <h3 class="client-upload__title">Add new inspiration</h3>
+      <%= form_with model: @new_document, url: client_event_designs_path(@event),
+                    data: { document_upload_form: true, presign_url: presign_event_documents_path(@event) },
+                    html: { class: "client-upload__form" } do |form| %>
+        <% if @new_document.errors.any? %>
+          <div class="client-upload__errors">
+            <h4><%= pluralize(@new_document.errors.count, "error") %> prevented uploading:</h4>
+            <ul>
+              <% @new_document.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div class="client-upload__field">
+          <%= form.label :title, "Title (optional)" %>
+          <%= form.text_field :title, class: "client-upload__input" %>
+        </div>
+
+        <div class="client-upload__field">
+          <%= form.label :file, "File" %>
+          <input type="file" id="document_file" data-document-upload-target="file" class="client-upload__file">
+          <p class="client-upload__status" data-document-upload-target="status">Select a file to upload to storage.</p>
+        </div>
+
+        <%= form.hidden_field :storage_uri %>
+        <%= form.hidden_field :checksum %>
+        <%= form.hidden_field :size_bytes %>
+        <%= form.hidden_field :content_type %>
+        <%= form.hidden_field :logical_id %>
+
+        <div class="client-upload__actions">
+          <%= form.submit "Submit inspiration", class: "client-upload__submit" %>
+        </div>
       <% end %>
-    </ul>
-  <% else %>
-    <div class="client-placeholder">
-      <p>No inspiration files yet. Your planner will add items once they’re ready.</p>
     </div>
-  <% end %>
+  </div>
 </section>
+
+<% content_for :scripts do %>
+  <%= render "documents/upload_script" %>
+<% end %>

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,14 +1,17 @@
 <%
   event = @event || @document.event
-  form_options = { model: [event, @document] }
+  form_options = { model: [event, @document], class: "documents-form" }
   if @document.new_record?
     presign_url = presign_event_documents_path(event)
     form_options[:data] = { document_upload_form: true, presign_url: presign_url }
   end
+  existing_versions = defined?(@existing_versions) ? @existing_versions : Document.none
+  reference_document = defined?(@reference_document) ? @reference_document : nil
 %>
+
 <%= form_with(**form_options) do |form| %>
   <% if @document.errors.any? %>
-    <div class="errors">
+    <div class="documents-form__errors">
       <h2><%= pluralize(@document.errors.count, "error") %> prevented saving:</h2>
       <ul>
         <% @document.errors.full_messages.each do |message| %>
@@ -18,49 +21,87 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :title %><br>
-    <%= form.text_field :title %>
-  </div>
+  <div class="documents-form__grid">
+    <div class="documents-form__fields">
+      <div class="documents-form__field">
+        <%= form.label :title %>
+        <%= form.text_field :title, class: "documents-form__input" %>
+      </div>
 
-  <div>
-    <%= form.label :source, "Document Type" %><br>
-    <%= form.select :source, options_for_select(Document.sources.keys.map { |key| [key.humanize, key] }, form.object.source || "staff_upload") %>
-  </div>
+      <div class="documents-form__field">
+        <%= form.label :source, "Document Type" %>
+        <%= form.select :source, options_for_select(Document.sources.keys.map { |key| [key.humanize, key] }, form.object.source || "staff_upload"), {}, class: "documents-form__select" %>
+      </div>
 
-  <% if form.object.new_record? %>
-    <div>
-      <label for="document_file">File</label><br>
-      <input type="file" id="document_file" data-document-upload-target="file">
+      <% if form.object.new_record? %>
+        <div class="documents-form__field">
+          <%= form.label :file, "File" %>
+          <input type="file" id="document_file" data-document-upload-target="file" class="documents-form__file-field">
+          <p class="documents-form__upload-status" data-document-upload-target="status">Select a file to upload to storage.</p>
+        </div>
+
+        <%= form.hidden_field :storage_uri %>
+        <%= form.hidden_field :checksum %>
+        <%= form.hidden_field :size_bytes %>
+        <%= form.hidden_field :content_type %>
+
+        <div class="documents-form__field">
+          <%= form.label :logical_id, "Existing logical ID (optional)" %>
+          <%= form.text_field :logical_id, class: "documents-form__input" %>
+          <p class="documents-form__hint">If provided, this upload becomes the next version of that document.</p>
+        </div>
+      <% else %>
+        <div class="documents-form__field">
+          <%= form.label :content_type %>
+          <%= form.text_field :content_type, class: "documents-form__input" %>
+        </div>
+      <% end %>
+
+      <div class="documents-form__checkbox">
+        <%= form.label :client_visible do %>
+          <%= form.check_box :client_visible %>
+          Share with client portal
+        <% end %>
+      </div>
+
+      <div class="documents-form__actions">
+        <%= form.submit class: "documents-form__submit" %>
+        <% back_path = @document.persisted? ? event_document_path(event, @document) : event_documents_path(event) %>
+        <%= link_to "Cancel", back_path, class: "documents-form__cancel" %>
+      </div>
     </div>
 
-    <p data-document-upload-target="status">Select a file to upload to R2.</p>
+    <aside class="documents-form__context">
+      <% if reference_document.present? %>
+        <h2>Replacing current version</h2>
+        <p class="documents-form__context-title">
+          <strong><%= reference_document.title %></strong>
+          <span class="documents-form__version-indicator"><%= document_version_badge(reference_document) %></span>
+        </p>
+        <p>This upload will become version <strong>v<%= reference_document.version + 1 %></strong> for logical ID <code><%= reference_document.logical_id %></code>.</p>
+      <% elsif @document.persisted? %>
+        <h2>Editing version details</h2>
+        <p>Version: <span class="documents-form__version-indicator"><%= document_version_badge(@document) %></span></p>
+        <p>Logical ID: <code><%= @document.logical_id %></code></p>
+      <% else %>
+        <h2>New document</h2>
+        <p>A new logical ID will be generated once the file is uploaded.</p>
+      <% end %>
 
-    <%= form.hidden_field :storage_uri %>
-    <%= form.hidden_field :checksum %>
-    <%= form.hidden_field :size_bytes %>
-    <%= form.hidden_field :content_type %>
-
-    <div>
-      <%= form.label :logical_id, "Existing logical ID (optional)" %><br>
-      <%= form.text_field :logical_id %>
-      <p>If provided, this upload becomes the next version of that document.</p>
-    </div>
-  <% else %>
-    <div>
-      <%= form.label :content_type %><br>
-      <%= form.text_field :content_type %>
-    </div>
-  <% end %>
-
-  <div>
-    <%= form.label :client_visible do %>
-      <%= form.check_box :client_visible %>
-      Share with client portal
-    <% end %>
-  </div>
-
-  <div>
-    <%= form.submit %>
+      <% if existing_versions.present? %>
+        <h3>Existing versions</h3>
+        <ul class="documents-form__version-list">
+          <% existing_versions.limit(5).each do |version| %>
+            <li>
+              <span class="documents-form__version-indicator"><%= document_version_badge(version) %></span>
+              <span class="documents-form__version-updated"><%= document_updated_timestamp(version) %></span>
+            </li>
+          <% end %>
+          <% if existing_versions.count > 5 %>
+            <li class="documents-form__version-more">and <%= existing_versions.count - 5 %> more…</li>
+          <% end %>
+        </ul>
+      <% end %>
+    </aside>
   </div>
 <% end %>

--- a/app/views/documents/_table.html.erb
+++ b/app/views/documents/_table.html.erb
@@ -1,0 +1,115 @@
+<%
+  documents ||= []
+  columns ||= %i[title version updated_at visibility source uploader size actions]
+  context = local_assigns.fetch(:context, :planner)
+  title_link = local_assigns[:title_link]
+  empty_message = local_assigns.fetch(:empty_message, "No documents available.")
+  active_document = local_assigns[:active_document]
+  paths = {
+    view: ->(doc) { event_document_path(event, doc) },
+    download: ->(doc) { download_event_document_path(event, doc) },
+    replace: ->(doc) { new_event_document_path(event, logical_id: doc.logical_id) },
+    edit: ->(doc) { edit_event_document_path(event, doc) }
+  }.merge(local_assigns[:paths] || {})
+%>
+
+<div class="documents-table">
+  <% if documents.any? %>
+    <table class="documents-table__table">
+      <thead>
+        <tr>
+          <% columns.each do |column| %>
+            <th scope="col" class="documents-table__header documents-table__header--<%= column %>">
+              <%= document_table_header(column) %>
+            </th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% documents.each do |document| %>
+          <% row_classes = ["documents-table__row"] %>
+          <% row_classes << "documents-table__row--outdated" unless document.is_latest? %>
+          <% row_classes << "documents-table__row--active" if active_document&.id == document.id %>
+          <tr class="<%= row_classes.join(' ') %>">
+            <% columns.each do |column| %>
+              <td class="documents-table__cell documents-table__cell--<%= column %>">
+                <% case column %>
+                <% when :title %>
+                  <div class="documents-table__title">
+                    <% link_target = if title_link.respond_to?(:call)
+                                       title_link.call(document)
+                                     elsif title_link
+                                       title_link
+                                     elsif context == :planner && paths[:view]
+                                       paths[:view].call(document)
+                                     end %>
+                    <% if link_target.present? %>
+                      <%= link_to document.title, link_target, class: "documents-table__title-link" %>
+                    <% else %>
+                      <span class="documents-table__title-label"><%= document.title %></span>
+                    <% end %>
+                    <% unless columns.include?(:version) %>
+                      <span class="documents-table__title-badge"><%= document_version_badge(document) %></span>
+                    <% end %>
+                  </div>
+                  <div class="documents-table__meta">
+                    <span class="documents-table__meta-label">Logical ID:</span>
+                    <code class="documents-table__meta-value"><%= document.logical_id %></code>
+                  </div>
+                  <div class="documents-table__hint"><%= document_latest_explanation(document) %></div>
+                <% when :version %>
+                  <%= document_version_badge(document) %>
+                <% when :updated_at %>
+                  <div class="documents-table__stack">
+                    <span><%= document_updated_timestamp(document) %></span>
+                    <small><%= time_ago_in_words(document.updated_at) %> ago</small>
+                  </div>
+                <% when :visibility %>
+                  <div class="documents-table__stack">
+                    <span><%= document_visibility_label(document) %></span>
+                    <small><%= document_visibility_hint(document) %></small>
+                  </div>
+                <% when :source %>
+                  <span><%= document_source_label_for(document) %></span>
+                <% when :uploader %>
+                  <span><%= document_uploader_label(document) %></span>
+                <% when :size %>
+                  <span><%= document_size_label(document) %></span>
+                <% when :actions %>
+                  <div class="documents-table__actions">
+                    <% if context == :planner %>
+                      <% if active_document&.id == document.id %>
+                        <span class="documents-table__action documents-table__action--current">Viewing</span>
+                      <% elsif paths[:view] %>
+                        <%= link_to "View", paths[:view].call(document), class: "documents-table__action" %>
+                      <% end %>
+                      <% if paths[:download] %>
+                        <%= link_to "Download", paths[:download].call(document), class: "documents-table__action" %>
+                      <% end %>
+                      <% if paths[:replace] %>
+                        <%= link_to "New version", paths[:replace].call(document), class: "documents-table__action" %>
+                      <% end %>
+                      <% if paths[:edit] %>
+                        <%= link_to "Edit", paths[:edit].call(document), class: "documents-table__action" %>
+                      <% end %>
+                    <% else %>
+                      <% if paths[:download] %>
+                        <%= link_to "Download", paths[:download].call(document), class: "documents-table__action" %>
+                      <% end %>
+                    <% end %>
+                  </div>
+                <% else %>
+                  <span><%= document.public_send(column) %></span>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="documents-table__empty">
+      <p><%= empty_message %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/documents/_upload_script.html.erb
+++ b/app/views/documents/_upload_script.html.erb
@@ -1,0 +1,115 @@
+<script type="module">
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("[data-document-upload-form]").forEach((form) => {
+      const fileInput = form.querySelector("#document_file");
+      const statusEl = form.querySelector("[data-document-upload-target='status']");
+      const submitButton = form.querySelector("input[type=submit], button[type=submit]");
+      const titleInput = form.querySelector("#document_title");
+      const storageUriInput = form.querySelector("#document_storage_uri");
+      const checksumInput = form.querySelector("#document_checksum");
+      const sizeInput = form.querySelector("#document_size_bytes");
+      const contentTypeInput = form.querySelector("#document_content_type");
+      const logicalIdInput = form.querySelector("#document_logical_id");
+
+      const csrfToken = document.querySelector("meta[name='csrf-token']")?.content;
+
+      if (submitButton) {
+        submitButton.disabled = true;
+      }
+
+      const resetStatus = () => {
+        if (statusEl) {
+          statusEl.textContent = "Select a file to upload to storage.";
+        }
+      };
+
+      const setError = (message) => {
+        if (statusEl) {
+          statusEl.textContent = message;
+        }
+        if (submitButton) {
+          submitButton.disabled = true;
+        }
+      };
+
+      const hexDigest = async (file) => {
+        const buffer = await file.arrayBuffer();
+        const digest = await crypto.subtle.digest("SHA-256", buffer);
+        return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+      };
+
+      fileInput?.addEventListener("change", async () => {
+        const file = fileInput.files?.[0];
+        if (!file) {
+          resetStatus();
+          return;
+        }
+
+        if (submitButton) {
+          submitButton.disabled = true;
+        }
+        if (statusEl) {
+          statusEl.textContent = "Preparing upload...";
+        }
+
+        try {
+          const body = {
+            filename: file.name,
+            content_type: file.type || "application/octet-stream",
+            logical_id: logicalIdInput?.value || null
+          };
+
+          const presignResponse = await fetch(form.dataset.presignUrl, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-CSRF-Token": csrfToken || ""
+            },
+            body: JSON.stringify(body)
+          });
+
+          if (!presignResponse.ok) {
+            throw new Error("Unable to get upload URL");
+          }
+
+          const presignData = await presignResponse.json();
+
+          if (statusEl) {
+            statusEl.textContent = "Uploading to storage...";
+          }
+
+          const uploadResponse = await fetch(presignData.upload_url, {
+            method: "PUT",
+            headers: {
+              "Content-Type": presignData.content_type
+            },
+            body: file
+          });
+
+          if (!uploadResponse.ok) {
+            throw new Error("Upload to storage failed");
+          }
+
+          const checksum = await hexDigest(file);
+
+          if (titleInput && !titleInput.value) titleInput.value = file.name;
+          if (storageUriInput) storageUriInput.value = presignData.storage_uri;
+          if (checksumInput) checksumInput.value = checksum;
+          if (sizeInput) sizeInput.value = file.size;
+          if (contentTypeInput) contentTypeInput.value = presignData.content_type;
+          if (logicalIdInput) logicalIdInput.value = presignData.logical_id;
+
+          if (statusEl) {
+            statusEl.textContent = "Upload ready. Click Save to store document metadata.";
+          }
+          if (submitButton) {
+            submitButton.disabled = false;
+          }
+        } catch (error) {
+          console.error(error);
+          setError("Upload failed. Please try again.");
+        }
+      });
+    });
+  });
+</script>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,5 +1,24 @@
-<h1>Edit Document</h1>
+<% provide :page_shell do %>
+  <div class="event-layout">
+    <%= render "events/sidebar_navigation", event: @event %>
 
-<%= render "form" %>
+    <div class="event-layout__main">
+      <%= render "shared/flash" %>
 
-<p><%= link_to "Back", document_path(@document) %></p>
+      <section class="event-section">
+        <header class="event-section__header event-section__header--document">
+          <div>
+            <p class="event-section__eyebrow">Documents</p>
+            <h1 class="event-section__title">Edit Document</h1>
+            <p class="event-section__lead">Update metadata for <strong><%= @document.title %></strong> (<%= document_version_badge(@document) %>).</p>
+          </div>
+          <%= link_to "Back to details", event_document_path(@event, @document), class: "event-section__cta event-section__cta--secondary" %>
+        </header>
+
+        <div class="event-section__body">
+          <%= render "form" %>
+        </div>
+      </section>
+    </div>
+  </div>
+<% end %>

--- a/app/views/documents/group.html.erb
+++ b/app/views/documents/group.html.erb
@@ -6,52 +6,35 @@
       <%= render "shared/flash" %>
 
       <section class="event-section">
-        <header class="event-section__header">
+        <header class="event-section__header event-section__header--document">
           <div>
             <p class="event-section__eyebrow">Documents</p>
             <h1 class="event-section__title"><%= @label %></h1>
-            <p class="event-section__lead">Showing files uploaded as <%= @label.downcase %>. Use the summary to navigate to other categories.</p>
+            <p class="event-section__lead">Showing files uploaded as <%= @label.downcase %>. Use the tabs to switch categories.</p>
           </div>
           <%= link_to "Upload Document", new_event_document_path(@event), class: "event-section__cta" %>
         </header>
 
         <div class="event-section__body">
-          <% if @documents.any? %>
-            <ul class="event-docs__grid">
-              <% @documents.each do |document| %>
-                <li class="event-docs__card">
-                  <header class="event-docs__card-header">
-                    <h2 class="event-docs__title"><%= document.title %></h2>
-                    <% unless document.is_latest? %>
-                      <span class="event-docs__badge">v<%= document.version %></span>
-                    <% end %>
-                  </header>
-                  <dl class="event-docs__meta">
-                    <div>
-                      <dt>Version</dt>
-                      <dd>v<%= document.version %></dd>
-                    </div>
-                    <div>
-                      <dt>Updated</dt>
-                      <dd><%= l(document.updated_at, format: :long) %></dd>
-                    </div>
-                    <div>
-                      <dt>Visibility</dt>
-                      <dd><%= document.client_visible? ? "Shared with client" : "Planner only" %></dd>
-                    </div>
-                  </dl>
-                  <div class="event-docs__actions">
-                    <%= link_to "Open", event_document_path(@event, document), class: "event-docs__link" %>
-                    <%= link_to "Download", download_event_document_path(@event, document), class: "event-docs__link" %>
-                  </div>
-                </li>
+          <nav class="documents-nav" aria-label="Document categories">
+            <%= link_to event_documents_path(@event), class: "documents-nav__link" do %>
+              <span>All documents</span>
+              <span class="documents-nav__count"><%= @event.documents.latest.count %></span>
+            <% end %>
+            <% @document_groups.each do |group| %>
+              <% classes = ["documents-nav__link"] %>
+              <% classes << "documents-nav__link--active" if group[:key].to_s == @source_key %>
+              <%= link_to document_group_path(@event, group[:key]), class: classes.join(" ") do %>
+                <span><%= document_source_label_text(group[:key]) %></span>
+                <span class="documents-nav__count"><%= group[:latest_count] %></span>
               <% end %>
-            </ul>
-          <% else %>
-            <div class="event-section__empty">
-              <p>No documents in this category yet.</p>
-            </div>
-          <% end %>
+            <% end %>
+          </nav>
+
+          <%= render "documents/table", event: @event, documents: @documents,
+                    columns: %i[title version updated_at visibility source uploader size actions],
+                    empty_message: "No documents in this category yet.",
+                    context: :planner %>
         </div>
       </section>
     </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -6,17 +6,33 @@
       <%= render "shared/flash" %>
 
       <section class="event-section">
-        <header class="event-section__header">
+        <header class="event-section__header event-section__header--document">
           <div>
             <p class="event-section__eyebrow">Documents</p>
             <h1 class="event-section__title">Files for <%= @event.name %></h1>
-            <p class="event-section__lead">Browse by category to jump straight to packets, planner uploads, or client contributions.</p>
+            <p class="event-section__lead">Review every file shared for this event or jump into a specific category below.</p>
           </div>
           <%= link_to "Upload Document", new_event_document_path(@event), class: "event-section__cta" %>
         </header>
 
         <div class="event-section__body">
-          <%= render "documents/summary_table", event: @event, groups: @document_groups %>
+          <nav class="documents-nav" aria-label="Document categories">
+            <%= link_to event_documents_path(@event), class: ["documents-nav__link", (current_page?(event_documents_path(@event)) ? "documents-nav__link--active" : nil)].compact.join(" ") do %>
+              <span>All documents</span>
+              <span class="documents-nav__count"><%= @documents.size %></span>
+            <% end %>
+            <% @document_groups.each do |group| %>
+              <%= link_to document_group_path(@event, group[:key]), class: "documents-nav__link" do %>
+                <span><%= document_source_label_text(group[:key]) %></span>
+                <span class="documents-nav__count"><%= group[:latest_count] %></span>
+              <% end %>
+            <% end %>
+          </nav>
+
+          <%= render "documents/table", event: @event, documents: @documents,
+                    columns: %i[title version updated_at visibility source uploader size actions],
+                    empty_message: "No documents have been uploaded yet. Upload a file to get started.",
+                    context: :planner %>
         </div>
       </section>
     </div>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,124 +1,32 @@
-<h1>Upload Document</h1>
+<% provide :page_shell do %>
+  <div class="event-layout">
+    <%= render "events/sidebar_navigation", event: @event %>
 
-<%= render "form" %>
+    <div class="event-layout__main">
+      <%= render "shared/flash" %>
 
-<p><%= link_to "Back", event_documents_path(@event) %></p>
+      <section class="event-section">
+        <header class="event-section__header event-section__header--document">
+          <div>
+            <p class="event-section__eyebrow">Documents</p>
+            <h1 class="event-section__title">Upload Document</h1>
+            <% if @reference_document %>
+              <p class="event-section__lead">This upload will replace <strong><%= @reference_document.title %></strong> (<%= document_version_badge(@reference_document) %>).</p>
+            <% else %>
+              <p class="event-section__lead">Select a file to share with your planning team or client portal.</p>
+            <% end %>
+          </div>
+          <%= link_to "Back to documents", event_documents_path(@event), class: "event-section__cta event-section__cta--secondary" %>
+        </header>
+
+        <div class="event-section__body">
+          <%= render "form" %>
+        </div>
+      </section>
+    </div>
+  </div>
+<% end %>
 
 <% content_for :scripts do %>
-  <script type="module">
-    document.addEventListener("DOMContentLoaded", () => {
-      const form = document.querySelector("[data-document-upload-form]");
-      if (!form) return;
-
-      const fileInput = form.querySelector("#document_file");
-      const statusEl = form.querySelector("[data-document-upload-target='status']");
-      const submitButton = form.querySelector("input[type=submit], button[type=submit]");
-      const titleInput = form.querySelector("#document_title");
-      const storageUriInput = form.querySelector("#document_storage_uri");
-      const checksumInput = form.querySelector("#document_checksum");
-      const sizeInput = form.querySelector("#document_size_bytes");
-      const contentTypeInput = form.querySelector("#document_content_type");
-      const logicalIdInput = form.querySelector("#document_logical_id");
-
-      const csrfToken = document.querySelector("meta[name='csrf-token']")?.content;
-
-      if (submitButton) {
-        submitButton.disabled = true;
-      }
-
-      const resetStatus = () => {
-        if (statusEl) {
-          statusEl.textContent = "Select a file to upload to R2.";
-        }
-      };
-
-      const setError = (message) => {
-        if (statusEl) {
-          statusEl.textContent = message;
-        }
-        if (submitButton) {
-          submitButton.disabled = true;
-        }
-      };
-
-      const hexDigest = async (file) => {
-        const buffer = await file.arrayBuffer();
-        const digest = await crypto.subtle.digest("SHA-256", buffer);
-        return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, "0")).join("");
-      };
-
-      fileInput?.addEventListener("change", async () => {
-        const file = fileInput.files?.[0];
-        if (!file) {
-          resetStatus();
-          return;
-        }
-
-        if (submitButton) {
-          submitButton.disabled = true;
-        }
-        if (statusEl) {
-          statusEl.textContent = "Preparing upload...";
-        }
-
-        try {
-          const body = {
-            filename: file.name,
-            content_type: file.type || "application/octet-stream",
-            logical_id: logicalIdInput?.value || null
-          };
-
-          const presignResponse = await fetch(form.dataset.presignUrl, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": csrfToken || ""
-            },
-            body: JSON.stringify(body)
-          });
-
-          if (!presignResponse.ok) {
-            throw new Error("Unable to get upload URL");
-          }
-
-          const presignData = await presignResponse.json();
-
-          if (statusEl) {
-            statusEl.textContent = "Uploading to storage...";
-          }
-
-          const uploadResponse = await fetch(presignData.upload_url, {
-            method: "PUT",
-            headers: {
-              "Content-Type": presignData.content_type
-            },
-            body: file
-          });
-
-          if (!uploadResponse.ok) {
-            throw new Error("Upload to storage failed");
-          }
-
-          const checksum = await hexDigest(file);
-
-          if (titleInput && !titleInput.value) titleInput.value = file.name;
-          if (storageUriInput) storageUriInput.value = presignData.storage_uri;
-          if (checksumInput) checksumInput.value = checksum;
-          if (sizeInput) sizeInput.value = file.size;
-          if (contentTypeInput) contentTypeInput.value = presignData.content_type;
-          if (logicalIdInput) logicalIdInput.value = presignData.logical_id;
-
-          if (statusEl) {
-            statusEl.textContent = "Upload ready. Click Save to store document metadata.";
-          }
-          if (submitButton) {
-            submitButton.disabled = false;
-          }
-        } catch (error) {
-          console.error(error);
-          setError("Upload failed. Please try again.");
-        }
-      });
-    });
-  </script>
+  <%= render "documents/upload_script" %>
 <% end %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,74 +1,114 @@
-<h1><%= @document.title %> (v<%= @document.version %>)</h1>
+<% provide :page_shell do %>
+  <div class="event-layout">
+    <%= render "events/sidebar_navigation", event: @event %>
 
-<p>Event: <%= link_to @event.name, event_path(@event) %></p>
-<p>Logical ID: <%= @document.logical_id %></p>
-<p>Latest version: <%= @document.is_latest? ? "Yes" : "No" %></p>
-<p>Content type: <%= @document.content_type %></p>
-<p>Size: <%= number_to_human_size(@document.size_bytes) %></p>
-<p>Storage key: <code><%= @document.storage_uri %></code></p>
-<p>Checksum: <code><%= @document.checksum %></code></p>
+    <div class="event-layout__main">
+      <%= render "shared/flash" %>
 
-<p>
-  <%= link_to "Download this version", download_event_document_path(@event, @document) %>
-  <% if @document.is_latest? %>
-    (latest)
-  <% else %>
-    | <%= link_to "Download latest version", download_event_document_path(@event, @versions.first) %>
-  <% end %>
-</p>
+      <section class="event-section documents-show">
+        <header class="event-section__header event-section__header--document">
+          <div>
+            <p class="event-section__eyebrow">Document</p>
+            <h1 class="event-section__title"><%= @document.title %></h1>
+            <p class="event-section__lead"><%= document_latest_explanation(@document) %></p>
+          </div>
+          <%= link_to "Upload new version", new_event_document_path(@event, logical_id: @document.logical_id), class: "event-section__cta" %>
+        </header>
 
-<section>
-  <h2>Version history</h2>
-  <table>
-    <thead>
-      <tr>
-        <th>Version</th>
-        <th>Uploaded</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @versions.each do |version| %>
-        <tr>
-          <td>v<%= version.version %></td>
-          <td><%= version.created_at&.to_fs(:long) || "—" %></td>
-          <td>
-            <% if version == @document %>
-              Viewing
+        <div class="event-section__body documents-show__body">
+          <section class="documents-show__summary" aria-labelledby="document-metadata-heading">
+            <h2 id="document-metadata-heading" class="documents-show__heading">File metadata</h2>
+            <dl class="documents-show__meta-grid">
+              <div>
+                <dt>Version</dt>
+                <dd><%= document_version_badge(@document) %></dd>
+              </div>
+              <div>
+                <dt>Logical ID</dt>
+                <dd><code><%= @document.logical_id %></code></dd>
+              </div>
+              <div>
+                <dt>Updated</dt>
+                <dd>
+                  <div><%= document_updated_timestamp(@document) %></div>
+                  <small><%= time_ago_in_words(@document.updated_at) %> ago</small>
+                </dd>
+              </div>
+              <div>
+                <dt>Visibility</dt>
+                <dd>
+                  <div><%= document_visibility_label(@document) %></div>
+                  <small><%= document_visibility_hint(@document) %></small>
+                </dd>
+              </div>
+              <div>
+                <dt>Source</dt>
+                <dd><%= document_source_label_for(@document) %></dd>
+              </div>
+              <div>
+                <dt>Uploader</dt>
+                <dd><%= document_uploader_label(@document) %></dd>
+              </div>
+              <div>
+                <dt>File size</dt>
+                <dd><%= document_size_label(@document) %></dd>
+              </div>
+              <div>
+                <dt>Content type</dt>
+                <dd><%= @document.content_type %></dd>
+              </div>
+              <div>
+                <dt>Storage key</dt>
+                <dd><code><%= @document.storage_uri %></code></dd>
+              </div>
+              <div>
+                <dt>Checksum</dt>
+                <dd><code><%= @document.checksum %></code></dd>
+              </div>
+            </dl>
+
+            <div class="documents-show__primary-actions">
+              <%= link_to "Download this version", download_event_document_path(@event, @document), class: "documents-show__action" %>
+              <% latest_version = @versions.first %>
+              <% if latest_version.present? && latest_version != @document %>
+                <%= link_to "Download latest version", download_event_document_path(@event, latest_version), class: "documents-show__action" %>
+              <% end %>
+              <%= link_to "Edit metadata", edit_event_document_path(@event, @document), class: "documents-show__action" %>
+              <%= button_to "Delete document", event_document_path(@event, @document), method: :delete, data: { confirm: "Delete this document?" }, class: "documents-show__danger" %>
+            </div>
+          </section>
+
+          <section class="documents-show__history" aria-labelledby="document-history-heading">
+            <h2 id="document-history-heading" class="documents-show__heading">Version history</h2>
+            <%= render "documents/table", event: @event, documents: @versions,
+                      columns: %i[version updated_at visibility source uploader actions],
+                      context: :planner,
+                      active_document: @document,
+                      empty_message: "No version history yet."
+            %>
+          </section>
+
+          <section class="documents-show__attachments" aria-labelledby="document-attachments-heading">
+            <h2 id="document-attachments-heading" class="documents-show__heading">Attachments</h2>
+            <%= render "attachments/list", attachments: @attachments %>
+          </section>
+
+          <section class="documents-show__attachments" aria-labelledby="document-attach-heading">
+            <h2 id="document-attach-heading" class="documents-show__heading">Attach to…</h2>
+            <% if @available_entities.any? %>
+              <% @available_entities.each do |entity| %>
+                <h3 class="documents-show__subheading"><%= entity_label(entity) %></h3>
+                <%= render "attachments/form", entity: entity, documents: documents_for_entity(entity) %>
+              <% end %>
             <% else %>
-              <%= link_to "View", event_document_path(@event, version) %>
+              <p>No available entities to attach.</p>
             <% end %>
-            |
-            <%= link_to "Download", download_event_document_path(@event, version) %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</section>
-
-<p>
-  <%= link_to "Upload new version", new_event_document_path(@event, logical_id: @document.logical_id) %> |
-  <%= link_to "Edit", edit_event_document_path(@event, @document) %> |
-  <%= button_to "Delete", event_document_path(@event, @document), method: :delete, data: { confirm: "Delete this document?" } %>
-</p>
-
-<section>
-  <h2>Attachments</h2>
-  <%= render "attachments/list", attachments: @attachments %>
-</section>
-
-<section>
-  <h2>Attach to…</h2>
-  <% if @available_entities.any? %>
-    <% @available_entities.each do |entity| %>
-      <h3><%= entity_label(entity) %></h3>
-      <%= render "attachments/form", entity: entity, documents: documents_for_entity(entity) %>
-    <% end %>
-  <% else %>
-    <p>No available entities to attach.</p>
-  <% end %>
-</section>
+          </section>
+        </div>
+      </section>
+    </div>
+  </div>
+<% end %>
 
 <% content_for :scripts do %>
   <%= render "attachments/upload_script" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Rails.application.routes.draw do
           patch :answer, to: "question_answers#update"
         end
       end
-      resources :designs, only: :index
+      resources :designs, only: %i[index create]
       resources :financials, only: :index
       resources :payments, only: :show do
         member do

--- a/test/controllers/client/designs_controller_test.rb
+++ b/test/controllers/client/designs_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+module Client
+  class DesignsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      log_in_as(users(:client_contact))
+      @event = events(:one)
+    end
+
+    test "shows planner and client uploads" do
+      get client_event_designs_url(@event)
+      assert_response :success
+      assert_select "h2", text: "Planner uploads"
+      assert_select ".client-upload__title", text: "Add new inspiration"
+    end
+
+    test "client can submit new inspiration" do
+      assert_difference("Document.client_upload.count") do
+        post client_event_designs_url(@event), params: {
+          document: {
+            title: "Ideas from Pinterest",
+            storage_uri: "documents/client/pinterest-v1.png",
+            checksum: "client-checksum-xyz",
+            size_bytes: 1024,
+            content_type: "image/png"
+          }
+        }
+      end
+
+      assert_redirected_to client_event_designs_url(@event)
+      document = Document.last
+      assert document.client_visible?
+      assert_equal "client_upload", document.source
+    end
+  end
+end

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -11,6 +11,16 @@ class DocumentsControllerTest < ActionDispatch::IntegrationTest
     get event_documents_url(@event)
     assert_response :success
     assert_select "h1", text: "Files for #{@event.name}"
+    assert_select ".documents-table__table"
+    assert_select ".documents-table__row", minimum: 1
+    assert_select ".documents-nav__link", text: /Planner Uploads/
+  end
+
+  test "group view shows version metadata" do
+    get packets_event_documents_url(@event)
+    assert_response :success
+    assert_select "h1", text: "Packets"
+    assert_select ".documents-table__cell--version", text: /v2/i
   end
 
   test "uploads new document" do

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,12 +1,74 @@
 contract_v1:
   event: one
   title: Production Contract
-  storage_uri: documents/contract-v1.pdf
+  storage_uri: documents/contracts/contract-v1.pdf
   checksum: contract-checksum-v1
   size_bytes: 2048
   logical_id: 11111111-1111-1111-1111-111111111111
   version: 1
   is_latest: true
   content_type: application/pdf
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  client_visible: false
+  source: staff_upload
+  created_at: <%= 5.days.ago %>
+  updated_at: <%= 5.days.ago %>
+
+welcome_packet_v1:
+  event: one
+  title: Welcome Packet
+  storage_uri: documents/packets/welcome-v1.pdf
+  checksum: welcome-checksum-v1
+  size_bytes: 3072
+  logical_id: 22222222-2222-2222-2222-222222222222
+  version: 1
+  is_latest: false
+  content_type: application/pdf
+  client_visible: true
+  source: packet
+  created_at: <%= 10.days.ago %>
+  updated_at: <%= 10.days.ago %>
+
+welcome_packet_v2:
+  event: one
+  title: Welcome Packet
+  storage_uri: documents/packets/welcome-v2.pdf
+  checksum: welcome-checksum-v2
+  size_bytes: 3584
+  logical_id: 22222222-2222-2222-2222-222222222222
+  version: 2
+  is_latest: true
+  content_type: application/pdf
+  client_visible: true
+  source: packet
+  created_at: <%= 4.days.ago %>
+  updated_at: <%= 4.days.ago %>
+
+design_board_v1:
+  event: one
+  title: Inspiration Board
+  storage_uri: documents/designs/board-v1.pdf
+  checksum: design-board-v1
+  size_bytes: 4096
+  logical_id: 33333333-3333-3333-3333-333333333333
+  version: 1
+  is_latest: true
+  content_type: application/pdf
+  client_visible: true
+  source: staff_upload
+  created_at: <%= 6.days.ago %>
+  updated_at: <%= 6.days.ago %>
+
+client_moodboard_v1:
+  event: one
+  title: Client Moodboard
+  storage_uri: documents/client/moodboard-v1.png
+  checksum: client-moodboard-v1
+  size_bytes: 5120
+  logical_id: 44444444-4444-4444-4444-444444444444
+  version: 1
+  is_latest: true
+  content_type: image/png
+  client_visible: true
+  source: client_upload
+  created_at: <%= 3.days.ago %>
+  updated_at: <%= 3.days.ago %>


### PR DESCRIPTION
## Summary
- swap the client designs upload form to use `client_event_designs_path`
- redirect the designs create action back to the proper `client_event_designs_path`
- update the client designs controller integration test to hit the `client_event_designs_url`

## Testing
- `bin/rails test test/controllers/client/designs_controller_test.rb` *(fails: missing gems in sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d38baa79bc8321b5583d16fe5b8650